### PR TITLE
Security Agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ The project requires **Python 3.13+** (`pyproject.toml` → `requires-python = "
 ### Dependency management
 
 - Package manager: **uv** (with `pyproject.toml` / `uv.lock`).
-- Dev dependencies: `uv sync --group dev` (includes `pytest`, `mkdocs`, `pip-audit`, `ruff`).
+- Dev dependencies: `uv sync --group dev` (includes `pytest`, `pip-audit`). `ruff` is not in the dev group; install it separately with `.venv/bin/pip install ruff` after sync.
 - ComfyUI CLI: `uv sync --group comfyui` (installs `comfy-cli`). Note: syncing one group removes packages from the other. For a full dev setup, install dev group first, then use `pip install` for ComfyUI's own requirements on top.
 - PyTorch: `pyproject.toml` directs Linux/Windows to CUDA wheels (`cu128`). On GPU-less VMs, replace with CPU-only wheels: `pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --force-reinstall`.
 - System dependency: `libsqlcipher-dev` is needed for the `sqlcipher3` Python package.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@
 
 This is a **ComfyUI custom-node extension** (MSS-Login) that adds RBAC, JWT auth, NSFW detection, and admin UI to ComfyUI. It is not a standalone app — it requires ComfyUI as its host.
 
+### Do NOT install or run ComfyUI
+
+**Do not install ComfyUI, `comfy-cli`, or attempt to launch a ComfyUI server.** The Cloud VM has no GPU, and downloading/running ComfyUI (~1 GB+ of dependencies) is a waste of time and resources. All tests and lint checks run without ComfyUI. Focus only on linting, testing, and editing the extension code itself.
+
 ### Python version
 
 The project requires **Python 3.13+** (`pyproject.toml` → `requires-python = ">=3.13"`). The venv is managed by `uv`.
@@ -14,8 +18,8 @@ The project requires **Python 3.13+** (`pyproject.toml` → `requires-python = "
 
 - Package manager: **uv** (with `pyproject.toml` / `uv.lock`).
 - Dev dependencies: `uv sync --group dev` (includes `pytest`, `pip-audit`). `ruff` is not in the dev group; install it separately with `.venv/bin/pip install ruff` after sync.
-- ComfyUI CLI: `uv sync --group comfyui` (installs `comfy-cli`). Note: syncing one group removes packages from the other. For a full dev setup, install dev group first, then use `pip install` for ComfyUI's own requirements on top.
-- PyTorch: `pyproject.toml` directs Linux/Windows to CUDA wheels (`cu128`). On GPU-less VMs, replace with CPU-only wheels: `pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --force-reinstall`.
+- **Do not** use `uv sync --group comfyui` or install `comfy-cli` — ComfyUI is not needed (see above).
+- PyTorch: `pyproject.toml` directs Linux/Windows to CUDA wheels (`cu128`). The Cloud VM has no GPU, so after `uv sync` you must replace them with CPU-only wheels: `.venv/bin/pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --force-reinstall`.
 - System dependency: `libsqlcipher-dev` is needed for the `sqlcipher3` Python package.
 
 ### Running tests
@@ -43,20 +47,7 @@ Tests are documented in `tests/README.md`. Quick reference:
 
 Note: the codebase has pre-existing ruff check errors (12 errors: F403, F405, F811, E722, F541) and format drift (64 files). These are not introduced by setup.
 
-### Running ComfyUI with the extension
-
-1. ComfyUI is installed at `ComfyUI/` via `comfy-cli`.
-2. The extension is symlinked: `ComfyUI/custom_nodes/mss-login -> /workspace`.
-3. A `.env` file is needed (copy from `.env.example`, set `SECRET_KEY`).
-4. Launch: `cd ComfyUI && ../.venv/bin/python main.py --cpu --listen 0.0.0.0 --port 8188`
-
 ### Known caveats
 
-- **`dotenvx` warning**: The extension tries to run `dotenvx` and `dotenvx-postinstall` at startup. These are optional; the warning is non-fatal. The `python-dotenvx` pip package is installed but the standalone binary install may fail in some environments.
-- **GPU-less VMs**: CUDA PyTorch wheels will fail to import `comfy.model_management` with "Torch not compiled with CUDA enabled" or "Found no NVIDIA driver". Install CPU-only PyTorch (see above).
-- **`install_deps.py` auto-install**: On Linux, the extension auto-installs CUDA PyTorch from `requirements_cuda.txt` on every startup (with captured output). This can be slow on first boot or when CPU-only torch is installed. Deps are already satisfied in Docker images with CUDA torch.
 - Always use the `.venv` Python (`.venv/bin/python`) per `.agent/rules/python-venv.mdc`.
-
-### Docker storage (`sombi/comfyui:base-torch2.8.0-cu128`)
-
-The default data directory is `~/.comfyui-mss-login/` (`/root/.comfyui-mss-login` in Docker). In the `sombi/comfyui` image, only `/workspace` is volume-mounted and persistent. **Set `MSS_LOGIN_DATA_DIR=/workspace/.comfyui-mss-login`** so data survives container recreation. See `utils/data_dir.py` for the full path logic.
+- **Do not install or run ComfyUI** in the Cloud VM — it is unnecessary and wastes resources. All tests and lint work without it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Updated `AGENTS.md` to explicitly instruct future agents not to install or run ComfyUI, as it is unnecessary and wastes resources in a GPU-less development environment. Also corrected a minor factual error regarding dev dependency groups.

## Bug

- **What was broken:**
    - `AGENTS.md` did not explicitly discourage ComfyUI installation, leading to potential resource waste on GPU-less VMs.
    - `AGENTS.md` incorrectly described the contents of the `dev` dependency group.
- **Root cause (if known):** Lack of explicit instructions tailored for a GPU-less cloud development environment.
- **How it’s fixed:**
    - Added a prominent "Do NOT install or run ComfyUI" section near the top.
    - Removed sections detailing ComfyUI installation, running, and Docker storage.
    - Corrected the description of dev dependencies, clarifying `mkdocs` and `ruff`'s origins.

## Type of change

- [x] Bug fix (non-breaking)

## Area

- [ ] Login / registration / MFA / API tokens
- [ ] RBAC / permissions / roles
- [ ] UI enforcement / settings panel
- [ ] Workflow save/load/delete blocking
- [ ] User environment / IP filtering
- [ ] NSFW Guard / gallery
- [ ] Backend / routes
- [x] Other (Documentation / Agent Instructions)

## How to verify

1. Open `AGENTS.md`.
2. Confirm the "Do NOT install or run ComfyUI" section is present and clear.
3. Verify that sections related to running ComfyUI or Docker storage are removed.
4. Check the "Dev dependencies" line for accuracy regarding `mkdocs` and `ruff`.

## Checklist

- [x] Code follows project style (e.g. Ruff); no new linter/format errors.
- [x] No secrets, credentials, or PII in code or commits.
- [x] Tested locally (repro before + after).
- [x] Docs/README updated if behavior or config changed.

## Related issues

Fixes #(issue number).

---
<p><a href="https://cursor.com/agents/bc-be41874d-1d6b-4fb1-bb41-fb91abb47394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be41874d-1d6b-4fb1-bb41-fb91abb47394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->