### PR TITLE
Fix 3 bugs from recent PRs: fetchApi response check, CSP-blocked inli…

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -22,7 +22,7 @@ from ..constants import (
     USERS_DB_CONFIG,
     WEB_DIR,
     experimental_loading_screen_enabled,
-experimental_mfa_enabled,
+    experimental_mfa_enabled,
 )
 from ..globals import access_control, jwt_auth, logger, routes, timeout, users_db
 from ..utils import user_env

--- a/web/html/loading.html
+++ b/web/html/loading.html
@@ -11,6 +11,7 @@
 
     <link rel="icon" href="/mss-login/assets/mss_logo.png" type="image/png">
     <link rel="stylesheet" type="text/css" href="/mss-login/css/styles.css">
+    <meta name="mss-loading-timeout-ms" content="{{LOADING_TIMEOUT_MS}}">
 
     <style>
         .loading-page .container { max-width: 420px; }
@@ -67,6 +68,5 @@
         </div>
     </div>
 </body>
-<script>window.MSS_LOGIN_LOADING_TIMEOUT_MS = {{LOADING_TIMEOUT_MS}};</script>
 <script src="/mss-login/js/loading.js"></script>
 </html>

--- a/web/js/loading.js
+++ b/web/js/loading.js
@@ -4,9 +4,8 @@
     // Same-origin tips (served by GET /mss-login/loading-tips.json; data dir or bundled)
     const TIPS_URL = "/mss-login/loading-tips.json";
     const TIP_INTERVAL_MS = 5000;
-    const AUTO_REDIRECT_MS = typeof window.MSS_LOGIN_LOADING_TIMEOUT_MS === "number"
-        ? window.MSS_LOGIN_LOADING_TIMEOUT_MS
-        : 15000;
+    const _metaTimeout = document.querySelector('meta[name="mss-loading-timeout-ms"]');
+    const AUTO_REDIRECT_MS = _metaTimeout ? (parseInt(_metaTimeout.content, 10) || 15000) : 15000;
 
     const tipEl = document.getElementById("loading-tip");
     const bannerEl = document.getElementById("loading-update-banner");

--- a/web/mss_login_settings.js
+++ b/web/mss_login_settings.js
@@ -3499,7 +3499,7 @@ app.ui.settings.addSetting({
                     method: "PUT",
                     body: JSON.stringify({ allow_guest_jwt: guestJwtCheck.checked })
                 });
-                if (res && res.status === "ok") {
+                if (res && res.ok) {
                     if (window.showToast) window.showToast(guestJwtCheck.checked ? "Guest JWT enabled." : "Guest JWT disabled.");
                 } else {
                     guestJwtCheck.checked = !guestJwtCheck.checked;
@@ -3556,7 +3556,7 @@ app.ui.settings.addSetting({
                     method: "PUT",
                     body: JSON.stringify({ topic: ntfyTopicInput.value.trim(), enabled_events: enabled })
                 });
-                if (res && res.status === "ok") {
+                if (res && res.ok) {
                     if (window.showToast) window.showToast("ntfy settings saved.");
                 }
             } catch (_) {}
@@ -3632,7 +3632,7 @@ app.ui.settings.addSetting({
                     method: "PUT",
                     body: JSON.stringify(payload)
                 });
-                if (res && res.status === "ok") {
+                if (res && res.ok) {
                     if (window.showToast) window.showToast("Experimental settings saved.");
                 }
             } catch (e) {


### PR DESCRIPTION
…ne script, import indent

Bug 1: Settings save handlers (guest-jwt, ntfy, experimental) compared Response.status (a number) to the string 'ok', which always evaluates to false. Guest JWT toggle always visually reverted; ntfy and experimental save toasts never appeared. Fix: use Response.ok.

Bug 2: loading.html set script-src 'self' CSP but injected an inline <script> to pass the configurable timeout. The inline script was silently blocked, making LOADING_TIMEOUT_SECONDS dead config. Fix: pass the value via a <meta> tag (CSP-safe) and read it in loading.js.

Bug 3: experimental_mfa_enabled import in routes/auth.py was at column 0 inside a parenthesized import block (valid syntax, broken formatting from PR #15). Fix: restore indentation.